### PR TITLE
Fixing "not" => "!"

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4400,10 +4400,10 @@ void EditorNode::_toggle_distraction_free_mode() {
 		}
 
 		if (screen == EDITOR_SCRIPT) {
-			script_distraction = not script_distraction;
+			script_distraction = !script_distraction;
 			set_distraction_free_mode(script_distraction);
 		} else {
-			scene_distraction = not scene_distraction;
+			scene_distraction = !scene_distraction;
 			set_distraction_free_mode(scene_distraction);
 		}
 	} else {


### PR DESCRIPTION
pull request #8532 from RameshRavone/patch-4 accidentally included "not" statements in C++, causing a compilation error during SCons build.